### PR TITLE
added information to the template from the view

### DIFF
--- a/website/models/product_model.py
+++ b/website/models/product_model.py
@@ -11,3 +11,6 @@ class Product(models.Model):
     description = models.TextField(blank=True, null=True)
     price = models.IntegerField()
     quantity = models.IntegerField()
+
+    def __str__(self):
+        return self.title

--- a/website/templates/website/404.html
+++ b/website/templates/website/404.html
@@ -1,0 +1,1 @@
+<h1>whoops! we couldn't find the thing</h1>

--- a/website/templates/website/product_detail.html
+++ b/website/templates/website/product_detail.html
@@ -1,0 +1,9 @@
+{% include "website/navbar.html" %}
+<h1>{{product.title}}</h1>
+<p>{{product.description}}</p>
+<p>price: {{product.price}}</p>
+<p>sold by: {{product.seller}}</p>
+<p>total quantity: {{product.quantity}}</p>
+<form>
+    <input type="submit" value="add to order">
+</form>

--- a/website/urls.py
+++ b/website/urls.py
@@ -10,4 +10,5 @@ urlpatterns = [
     url(r'^register$', views.register, name='register'),
     url(r'^sell$', views.sell_product, name='sell'),
     url(r'^products$', views.list_products, name='list_products'),
+    url(r'^products/(?P<product>[0-9]+)$', views.product_detail, name='product_detail')
 ]

--- a/website/views/__init__.py
+++ b/website/views/__init__.py
@@ -2,3 +2,4 @@ from .list_product_view import list_products
 from .sell_product_view import sell_product
 from .auth_view import register, login_user, user_logout
 from .index_view import index
+from .product_detail_view import product_detail

--- a/website/views/product_detail_view.py
+++ b/website/views/product_detail_view.py
@@ -23,9 +23,6 @@ def product_detail(request, product):
     # currently the product is coming from the url
     current_product = next((item for item in all_products if int(item.id)==int(product)), None)
 
-    for key, value in current_product.__dict__.items():
-        print(key, value)
-
     # define the template to be used
     template_name = 'website/product_detail.html'
     if current_product != None:

--- a/website/views/product_detail_view.py
+++ b/website/views/product_detail_view.py
@@ -1,0 +1,35 @@
+""" 
+    module: product detail view
+    author: riley mathews
+    purpose: to create a function based view that will show the details of a single product
+"""
+from django.http import HttpResponse
+from website.models import Product
+from django.shortcuts import render
+
+def product_detail(request, product):
+    """function to make the view for a product detail
+    
+    Arguments:
+        request {http} -- the request that triggered the function
+        product {string} -- passed into the function from the url, expected to be the id of the product we are looking for
+    
+    Returns:
+        render -- function either renders the product detail html page, or an error page if the product was not found
+    """
+    # get all of the products
+    all_products = Product.objects.all()
+    # find the product who's id is equal to the one passed to the function
+    # currently the product is coming from the url
+    current_product = next((item for item in all_products if int(item.id)==int(product)), None)
+
+    for key, value in current_product.__dict__.items():
+        print(key, value)
+
+    # define the template to be used
+    template_name = 'website/product_detail.html'
+    if current_product != None:
+        return render(request, template_name, {'product': current_product})
+    else:
+        return render(request, 'website/404.html', {})
+


### PR DESCRIPTION
## DESCRIPTION
references ticket #10 
user can now navigate to the url .../products/[id of a product] and be taken to a detail view for that product in the database.

## How to pull down
Commands

```
git fetch --all
git checkout rm-product-detail-view
```

## Steps to test

1. Start virtual environment
1. Make sure Django server is running
1. You will need a user in the database to create a product to test with
1. Probably the easiest way to get a user in the database is to run `python manage.py createsuperuser` and follow the prompts
1. you can then open up the database with db browser and manually create an entry for a product using seller_id: 1 to link it to the user you just created
1. load up the website and navigate to url rootdomain/products/1 and your product should be listed
1. if you navigate to an id that is not in the database such as rootdomain/products/3 (assuming there is not 3 products in the database) you should get an error html template served rather than a django error. 

## What you changed
1. added a view for product detail and added a url to route to it. 
1. I created a template html file for product detail, and a 404.html that we can link to for manually routing to when our code comes up with null.

## What was added to read me

## Final Checklist
Before merging.
1. Has each file changed been reviewed?
2. Has the readme been updated to reflect changes made?
3. Has a teammate approved the PR?

Then Ship It!
