### PR TITLE
Rm adding products

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ obj
 *.db
 *.sqlite3
 .vscode
+.DS_Store

--- a/website/models/order_model.py
+++ b/website/models/order_model.py
@@ -16,3 +16,6 @@ class Order(models.Model):
     payment_type = models.ForeignKey(PaymentType, on_delete=models.CASCADE, blank=True, null=True)
     date_created = models.DateField()
     date_closed = models.DateField(blank=True, null=True)
+
+    def __str__(self):
+        return f'{self.user} {self.date_created}'

--- a/website/models/order_model.py
+++ b/website/models/order_model.py
@@ -13,6 +13,6 @@ from .product_model import Product
 class Order(models.Model):
     products = models.ManyToManyField(Product)
     user = models.ForeignKey(User, on_delete=models.CASCADE)
-    payment_type = models.ForeignKey(PaymentType, on_delete=models.CASCADE, blank=True)
+    payment_type = models.ForeignKey(PaymentType, on_delete=models.CASCADE, blank=True, null=True)
     date_created = models.DateField()
-    date_closed = models.DateField(blank=True)
+    date_closed = models.DateField(blank=True, null=True)

--- a/website/templates/website/product_add_sucsess.html
+++ b/website/templates/website/product_add_sucsess.html
@@ -1,2 +1,2 @@
 {% include "website/navbar.html" %}
-<h1>Your product was added to your cart!</h1>
+<h1>{{product.title}} was added to your cart!</h1>

--- a/website/templates/website/product_add_sucsess.html
+++ b/website/templates/website/product_add_sucsess.html
@@ -1,0 +1,2 @@
+{% include "website/navbar.html" %}
+<h1>Your product was added to your cart!</h1>

--- a/website/templates/website/product_detail.html
+++ b/website/templates/website/product_detail.html
@@ -4,6 +4,7 @@
 <p>price: {{product.price}}</p>
 <p>sold by: {{product.seller}}</p>
 <p>total quantity: {{product.quantity}}</p>
-<form>
+<form method="POST">
+    {% csrf_token %}
     <input type="submit" value="add to order">
 </form>

--- a/website/views/product_detail_view.py
+++ b/website/views/product_detail_view.py
@@ -4,8 +4,9 @@
     purpose: to create a function based view that will show the details of a single product
 """
 from django.http import HttpResponse
-from website.models import Product
+from website.models import Product, Order
 from django.shortcuts import render
+import datetime
 
 def product_detail(request, product):
     """function to make the view for a product detail
@@ -24,22 +25,34 @@ def product_detail(request, product):
     current_product = next((item for item in all_products if int(item.id)==int(product)), None)
 
     # define the template to be used
-    template_name = 'website/product_detail.html'
-    if current_product != None:
-        return render(request, template_name, {'product': current_product})
-    else:
-        return render(request, 'website/404.html', {})
+    if request.method == "GET":
+        template_name = 'website/product_detail.html'
+        if current_product != None:
+            return render(request, template_name, {'product': current_product})
+        else:
+            return render(request, 'website/404.html', {})
 
-
+    elif request.method == "POST":
     # todo for adding product to order model
-
     # get users orders
-    
+        current_user = request.user
+        print(current_user.order_set.all())
+        users_orders = current_user.order_set.all()
+        
     # try to find one that has not yet been closed
-
+        open_order = next((order for order in users_orders if order.date_closed == None), None)
+        print(open_order)
     # add the product to that order
 
     # if the user has no open orders create one
 
     # add product to that order
+        return render(request, 'website/404.html', {})
 
+    # new_order = Order(
+        #     user=current_user,
+        #     payment_type=None,
+        #     date_created=datetime.datetime.now(),
+        #     date_closed=None,
+        # )
+        # new_order.save()

--- a/website/views/product_detail_view.py
+++ b/website/views/product_detail_view.py
@@ -24,7 +24,6 @@ def product_detail(request, product):
     # currently the product is coming from the url
     current_product = next((item for item in all_products if int(item.id)==int(product)), None)
 
-    # define the template to be used
     if request.method == "GET":
         template_name = 'website/product_detail.html'
         if current_product != None:
@@ -33,26 +32,25 @@ def product_detail(request, product):
             return render(request, 'website/404.html', {})
 
     elif request.method == "POST":
-    # todo for adding product to order model
     # get users orders
         current_user = request.user
-        print(current_user.order_set.all())
         users_orders = current_user.order_set.all()
         
     # try to find one that has not yet been closed
         open_order = next((order for order in users_orders if order.date_closed == None), None)
-        print(open_order)
     # add the product to that order
-
+        if open_order != None:
+            open_order.products.add(current_product)
     # if the user has no open orders create one
-
+        else:
+            new_order = Order(
+                user=current_user,
+                payment_type=None,
+                date_created=datetime.datetime.now(),
+                date_closed=None,
+            )
+            new_order.save()
     # add product to that order
-        return render(request, 'website/404.html', {})
+            new_order.products.add(current_product)
 
-    # new_order = Order(
-        #     user=current_user,
-        #     payment_type=None,
-        #     date_created=datetime.datetime.now(),
-        #     date_closed=None,
-        # )
-        # new_order.save()
+        return render(request, 'website/product_add_sucsess.html', {})

--- a/website/views/product_detail_view.py
+++ b/website/views/product_detail_view.py
@@ -53,4 +53,4 @@ def product_detail(request, product):
     # add product to that order
             new_order.products.add(current_product)
 
-        return render(request, 'website/product_add_sucsess.html', {})
+        return render(request, 'website/product_add_sucsess.html', {'product': current_product})


### PR DESCRIPTION
## DESCRIPTION
added the ability to add products to an order

## How to pull down
Commands

```
git fetch --all
git checkout rm-adding-products
```

## Steps to test

1. Start virtual environment
1. Make sure Django server is running
1. Make migrations to make sure you have the new order model in your database
1. Load up webpage, make sure you are logged in, and navigate to a product detail page
1. If you have not clicked the 'add to order' button yet you should have no open orders in your database
1. click the 'add to order' button. 
1. there should now be an order object in the database as well as an item on the order_products table that references it. 
1. navigate to another product page and add that product as well. it should be added to the same open order in the many to many table. 
1. 'close' the open order by going into db browser and manually adding a date field to the open order
1. save the database
1. try to add a product again. The new product should be added to a second order that was created in the database since you had no open orders before. 

## What you changed
Added logic to the product detail view for when the add to order button is clicked so that the product will be added to an order. With the current logic it 'should' be impossible that a user will have more than one open order at a time. 

## What was added to read me

## Final Checklist
Before merging.
1. Has each file changed been reviewed?
2. Has the readme been updated to reflect changes made?
3. Have 2 teammates approved the PR?

Then Ship It!
